### PR TITLE
Fixed getAllCorridorsBug, Object.create bug, and disable input if entity is "premade"

### DIFF
--- a/frontend/src/DB.ts
+++ b/frontend/src/DB.ts
@@ -1,14 +1,14 @@
-import { default as firebaseKey } from "./certs/firebase_key.json"
+import { plainToClass } from "class-transformer";
 import firebase from "firebase/app";
 import "firebase/firestore";
-import { Configuration } from './models/Configuration';
-import { BACKEND_URL } from './constants/Backend';
-import { plainToClass } from "class-transformer";
 import { Authenticator } from './Authenticator';
-import { RoomCategory } from "./models/RoomCategory";
+import { default as firebaseKey } from "./certs/firebase_key.json";
+import { BACKEND_URL } from './constants/Backend';
+import { Configuration } from './models/Configuration';
 import { CorridorCategory } from "./models/CorridorCategory";
-import { Monster } from "./models/Monster";
 import { Item } from "./models/Item";
+import { Monster } from "./models/Monster";
+import { RoomCategory } from "./models/RoomCategory";
 import { Trap } from "./models/Trap";
 
 export class DB {
@@ -138,9 +138,9 @@ export class DB {
             if (!data.valid) {
                 return data;
             }
-            var corridorCats: RoomCategory[] = [];
+            var corridorCats: CorridorCategory[] = [];
             data.response.forEach((element: Object) => {
-                corridorCats.push(plainToClass(RoomCategory, element))
+                corridorCats.push(plainToClass(CorridorCategory, element))
             });
             return { valid: true, "response": corridorCats };
         } catch (error) {

--- a/frontend/src/components/ConfigurationEditor.tsx
+++ b/frontend/src/components/ConfigurationEditor.tsx
@@ -72,11 +72,9 @@ const useStyles = makeStyles((theme) =>  ({
     }
 }));
 
-
 type Props = {
     configuration?: Configuration;
 }
-
 
 
 function ConfigurationEditor(props: Props) {
@@ -116,7 +114,7 @@ function ConfigurationEditor(props: Props) {
     }, [props.configuration])
 
     const handleChange = (name: keyof Configuration, value: valueOf<Configuration>) => {
-        setConfiguration(Object.assign(Object.create(configuration), configuration, {[name]: value}))
+        setConfiguration(Object.assign(Object.create(Object.getPrototypeOf(configuration)), configuration, {[name]: value}))
     }
 
     // REQ-18: Save.MapConfiguration - The system allows logged -in users to save the entire map configuration(both Map Level and Region Level) as a Preset.
@@ -248,7 +246,7 @@ function ConfigurationEditor(props: Props) {
                         <Typography>Map Level Options</Typography>
                     </AccordionSummary>
                     <AccordionDetails>
-                        <MapLevelConfiguration configuration={configuration} onChange={handleChange}/>
+                        <MapLevelConfiguration isSaving={isSaving} configuration={configuration} onChange={handleChange}/>
                     </AccordionDetails>
                 </Accordion>
                 <Accordion expanded={true}>
@@ -274,7 +272,7 @@ function ConfigurationEditor(props: Props) {
                         </Tooltip>
                     </AccordionSummary>
                     <AccordionDetails>
-                        <RegionLevelConfiguration configuration={configuration} onChange={handleChange}/>
+                        <RegionLevelConfiguration isSaving={isSaving} configuration={configuration} onChange={handleChange}/>
                     </AccordionDetails>
                 </Accordion>
             </Paper>

--- a/frontend/src/components/CorridorCategoryEditor.tsx
+++ b/frontend/src/components/CorridorCategoryEditor.tsx
@@ -118,18 +118,18 @@ export default function CorridorCategoryEditor(props: Props) {
         })
       }
     }
-    setCorridorCategory(Object.assign(Object.create(corridorCategory), corridorCategory, { [name]: value }) );
+    setCorridorCategory(Object.assign(Object.create(Object.getPrototypeOf(corridorCategory)), corridorCategory, { [name]: value }) );
   }
 
   const handleDeleteClick = (name: keyof CorridorCategory, index: number) => {
-    var updatedList = Object.create(corridorCategory[name] as Probabilities<any>);
+    var updatedList = Object.create(Object.getPrototypeOf(corridorCategory[name]) as Probabilities<any>);
     updatedList = Object.assign(updatedList, corridorCategory[name]);
     updatedList.remove(index);
     handleChange(name, updatedList);
   }
 
   const handleSelect = (name: keyof CorridorCategory, item: any) => {
-    var updatedList = Object.create(corridorCategory[name] as Probabilities<any>);
+    var updatedList = Object.create(Object.getPrototypeOf(corridorCategory[name]) as Probabilities<any>);
     updatedList = Object.assign(updatedList, corridorCategory[name]);
     updatedList.add(item);
     handleChange(name, updatedList);
@@ -160,7 +160,7 @@ export default function CorridorCategoryEditor(props: Props) {
   }
 
   const handleMonsterSave = (newMonster: Monster) => {
-    var updatedList = Object.create(corridorCategory.monsters as Probabilities<Monster>);
+    var updatedList = Object.create(Object.getPrototypeOf(corridorCategory.monsters) as Probabilities<Monster>);
     updatedList = Object.assign(updatedList, corridorCategory.monsters);
     updatedList.updateObject(monsterToEdit!, newMonster);
     handleChange(nameOf<CorridorCategory>("monsters"), updatedList);
@@ -186,7 +186,7 @@ export default function CorridorCategoryEditor(props: Props) {
   }
 
   const handleItemSave = (newItem: Item) => {
-    var updatedList = Object.create(corridorCategory.items as Probabilities<Item>);
+    var updatedList = Object.create(Object.getPrototypeOf(corridorCategory.items) as Probabilities<Item>);
     updatedList = Object.assign(updatedList, corridorCategory.items);
     updatedList.updateObject(itemToEdit!, newItem);
     handleChange(nameOf<CorridorCategory>("items"), updatedList);
@@ -212,7 +212,7 @@ export default function CorridorCategoryEditor(props: Props) {
   }
 
   const handleTrapSave = (newTrap: Trap) => {
-    var updatedList = Object.create(corridorCategory.traps as Probabilities<Trap>);
+    var updatedList = Object.create(Object.getPrototypeOf(corridorCategory.traps) as Probabilities<Trap>);
     updatedList = Object.assign(updatedList, corridorCategory.traps);
     updatedList.updateObject(trapToEdit!, newTrap);
     handleChange(nameOf<CorridorCategory>("traps"), updatedList);

--- a/frontend/src/components/CorridorCategoryEditor.tsx
+++ b/frontend/src/components/CorridorCategoryEditor.tsx
@@ -81,7 +81,7 @@ CorridorCategoryEditor.defaultProps = {
 }
 
 export default function CorridorCategoryEditor(props: Props) {
-  const editMode: boolean = props.corridorCategory !== undefined
+  const editMode: boolean = props.corridorCategory !== undefined && !props.corridorCategory.premade;
   const classes = useStyles();
 
   const [corridorCategory, setCorridorCategory] = useState(() => {
@@ -282,7 +282,7 @@ export default function CorridorCategoryEditor(props: Props) {
           disableTypography
           id="form-dialog-title">
           <Grid container alignItems="center">
-              <Typography component={'span'} variant="h6">{editMode ? "Edit" : "Add"} Corridor Category</Typography>
+              <Typography component={'span'} variant="h6">{editMode ? "Edit" : viewMode ? "View" : "Add"} Corridor Category</Typography>
               <Tooltip
                   arrow
                   classes={{ tooltip: classes.customWidth }}

--- a/frontend/src/components/DifficultySlider.tsx
+++ b/frontend/src/components/DifficultySlider.tsx
@@ -1,19 +1,28 @@
 import FormLabel from '@material-ui/core/FormLabel';
 import Slider from '@material-ui/core/Slider';
-import {Configuration} from '../models/Configuration';
+import { Configuration } from '../models/Configuration';
 
 type Props = {
+    disabled?: boolean;
     value: number;
     onChange: (value: number) => void;
+}
+
+DifficultySlider.defaultProps = {
+    disabled: false,
 }
 
 function DifficultySlider(props: Props) {
     return (
         <div>
-            <FormLabel id="input-slider">
+            <FormLabel
+                disabled={props.disabled}
+                id="input-slider"
+            >
                 Difficulty Level
             </FormLabel>
             <Slider
+                disabled={props.disabled}
                 aria-labelledby="input-slider"
                 value={props.value}
                 onChange={(e,v) => props.onChange(v as number)}

--- a/frontend/src/components/ItemEditor.tsx
+++ b/frontend/src/components/ItemEditor.tsx
@@ -47,7 +47,7 @@ ItemEditor.defaultProps = {
 }
 
 export default function ItemEditor(props: Props) {
-  const editMode: boolean = props.item !== undefined
+  const editMode: boolean = props.item !== undefined && !props.item.premade;
   const classes = useStyles();
 
   const [viewMode, setViewMode] = useState(props.viewOnly);
@@ -116,7 +116,7 @@ export default function ItemEditor(props: Props) {
           className={classes.root}
           disableTypography
           id="form-dialog-title">
-          <Typography component={'span'} variant="h6">{editMode ? "Edit" : "Add"} Item</Typography>
+          <Typography component={'span'} variant="h6">{editMode ? "Edit" : viewMode ? "View" : "Add"} Item</Typography>
           {viewMode && editMode &&
             <IconButton aria-label="edit" className={classes.editButton} onClick={handleEditClick}>
               <EditIcon />

--- a/frontend/src/components/ItemEditor.tsx
+++ b/frontend/src/components/ItemEditor.tsx
@@ -75,7 +75,7 @@ export default function ItemEditor(props: Props) {
         return
       }
     }
-    setItem(Object.assign(Object.create(item), item, { [name]: value }) );
+    setItem(Object.assign(Object.create(Object.getPrototypeOf(item)), item, { [name]: value }) );
   }
 
   const handleEditClick = () => {

--- a/frontend/src/components/MapLevelConfiguration.tsx
+++ b/frontend/src/components/MapLevelConfiguration.tsx
@@ -1,24 +1,32 @@
 import React from 'react';
-import { Size } from "../constants/Size";
 import { CorridorComplexity } from "../constants/CorridorComplexity";
 import { CorridorLength } from "../constants/CorridorLength";
-import DifficultySlider from './DifficultySlider';
+import { Size } from "../constants/Size";
+import { Configuration } from '../models/Configuration';
+import { nameOf, valueOf } from '../utils/util';
 import EnumRadio from './common/EnumRadio';
-import {Configuration} from '../models/Configuration';
-import {nameOf, valueOf} from '../utils/util';
+import DifficultySlider from './DifficultySlider';
 
 type Props = {
+    isSaving: boolean;
     configuration: Configuration;
     onChange: (name: keyof Configuration, value: valueOf<Configuration>)=>void;
 };
 
 const MapLevelConfiguration = React.memo(
     (props: Props) => {
+
+        var disabled = props.configuration.premade || props.isSaving
         return (
             <div>
-                <DifficultySlider onChange={(value: number) => props.onChange(nameOf<Configuration>("difficulty"), value)} value={props.configuration.difficulty}/>
+                <DifficultySlider
+                    disabled={disabled}
+                    onChange={(value: number) => props.onChange(nameOf<Configuration>("difficulty"), value)}
+                    value={props.configuration.difficulty}
+                />
                 <div>
                     <EnumRadio<Size>
+                        disabled={disabled}
                         enum={Size}
                         label="Map Size"
                         value={props.configuration.mapSize}
@@ -26,6 +34,7 @@ const MapLevelConfiguration = React.memo(
                 </div>
                 <div>
                     <EnumRadio<CorridorComplexity>
+                        disabled={disabled}
                         enum={CorridorComplexity}
                         label="Corridor Complexity"
                         value={props.configuration.corridorComplexity}
@@ -33,6 +42,7 @@ const MapLevelConfiguration = React.memo(
                 </div>
                 <div>
                     <EnumRadio<CorridorLength>
+                        disabled={disabled}
                         enum={CorridorLength}
                         label="Corridor Length"
                         value={props.configuration.corridorLength}

--- a/frontend/src/components/MonsterEditor.tsx
+++ b/frontend/src/components/MonsterEditor.tsx
@@ -14,7 +14,6 @@ import { Monster } from '../models/Monster';
 import { nameOf, valueOf } from '../utils/util';
 
 
-
 const useStyles = makeStyles((theme) => ({
   root: {
     margin: 0,
@@ -45,7 +44,7 @@ MonsterEditor.defaultProps = {
 }
 
 export default function MonsterEditor(props: Props) {
-  const editMode: boolean = props.monster !== undefined
+  const editMode: boolean = props.monster !== undefined && !props.monster.premade;
   const classes = useStyles();
 
   const [viewMode, setViewMode] = useState(props.viewOnly);
@@ -110,7 +109,7 @@ export default function MonsterEditor(props: Props) {
           className={classes.root}
           disableTypography
           id="form-dialog-title">
-          <Typography component={'span'} variant="h6">{editMode ? "Edit" : "Add"} Monster</Typography>
+          <Typography component={'span'} variant="h6">{editMode ? "Edit" : viewMode ? "View" : "Add"} Monster</Typography>
           {viewMode && editMode &&
             <IconButton aria-label="edit" className={classes.editButton} onClick={handleEditClick}>
               <EditIcon />

--- a/frontend/src/components/MonsterEditor.tsx
+++ b/frontend/src/components/MonsterEditor.tsx
@@ -69,7 +69,7 @@ export default function MonsterEditor(props: Props) {
         })
       }
     }
-    setMonster(Object.assign(Object.create(monster), monster, { [name]: value }) );
+    setMonster(Object.assign(Object.create(Object.getPrototypeOf(monster)), monster, { [name]: value }) );
   }
 
   const handleEditClick = () => {

--- a/frontend/src/components/RegionLevelConfiguration.tsx
+++ b/frontend/src/components/RegionLevelConfiguration.tsx
@@ -27,12 +27,15 @@ const useStyles = makeStyles({
 });
 
 type Props = {
+    isSaving: boolean;
     configuration: Configuration;
     onChange: (name: keyof Configuration, value: valueOf<Configuration>)=>void;
 }
 
 const RegionLevelConfiguration = memo(
     (props: Props) => {
+        var disabled = props.isSaving || props.configuration.premade;
+
         const classes = useStyles();
         const [addRoomDialogOpen, setAddRoomDialogOpen] = useState(false);
         const [addCorridorDialogOpen, setAddCorridorDialogOpen] = useState(false);
@@ -44,7 +47,7 @@ const RegionLevelConfiguration = memo(
         const [selectingDefault, setSelectingDefault] = useState(false);
 
         const handleDeleteClick = (name: keyof Configuration, index: number) => {
-            var updatedList = Object.create(props.configuration[name] as Probabilities<any>);
+            var updatedList = Object.create(Object.getPrototypeOf(props.configuration[name]) as Probabilities<any>);
             updatedList = Object.assign(updatedList, props.configuration[name]);
             updatedList.remove(index);
             props.onChange(name, updatedList);
@@ -59,7 +62,7 @@ const RegionLevelConfiguration = memo(
          }
 
         const handleSelect = (name: keyof Configuration, rc: RegionCategory) => {
-            var updatedList = Object.create(props.configuration[name] as Probabilities<any>);
+            var updatedList = Object.create(Object.getPrototypeOf(props.configuration[name]) as Probabilities<any>);
             updatedList = Object.assign(updatedList, props.configuration[name]);
             updatedList.add(rc);
             props.onChange(name, updatedList);
@@ -124,7 +127,7 @@ const RegionLevelConfiguration = memo(
         }
 
         const handleSave = (name: keyof Configuration, rc: RegionCategory) => {
-            var updatedList = Object.create(props.configuration[name] as Probabilities<any>);
+            var updatedList = Object.create(Object.getPrototypeOf(props.configuration[name]) as Probabilities<any>);
             updatedList = Object.assign(updatedList, props.configuration[name]) as Probabilities<any>;
             if (roomCategoryToEdit !== undefined) {
                 updatedList.updateObject(roomCategoryToEdit, rc);
@@ -141,23 +144,25 @@ const RegionLevelConfiguration = memo(
         return (
             <div style={{width: '100%'}}>
                 <div className={classes.listLabel}>
-                    <FormLabel required>Default Room</FormLabel>
-                    <IconButton onClick={handleSelectDefaultRoomClick} aria-label="add" color="primary">
+                    <FormLabel disabled={disabled} required>Default Room</FormLabel>
+                    <IconButton disabled={disabled} onClick={handleSelectDefaultRoomClick} aria-label="add" color="primary">
                         <ListIcon/>
                     </IconButton>
                 </div>
                 <NameList
+                    disabled={disabled}
                     onClick={handleDefaultRoomClick}
                     list={props.configuration.defaultRoomCategory ? [props.configuration.defaultRoomCategory] : []}
                 />
                 <div className={classes.listLabel}>
-                    <FormLabel>Rooms</FormLabel>
-                    <IconButton onClick={handleAddRoomClick} aria-label="add" color="primary">
+                    <FormLabel disabled={disabled}>Rooms</FormLabel>
+                    <IconButton disabled={disabled} onClick={handleAddRoomClick} aria-label="add" color="primary">
                         <AddBoxIcon/>
                     </IconButton>
                 </div>
 
                 <ProbabilityNameList
+                    disabled={disabled}
                     showProbs
                     showDelete
                     list={props.configuration.roomCategories}
@@ -166,22 +171,24 @@ const RegionLevelConfiguration = memo(
                     onProbUpdate={(newList) => props.onChange(nameOf<Configuration>("roomCategories"), newList!)}
                 />
                 <div className={classes.listLabel}>
-                    <FormLabel required>Default Corridor</FormLabel>
-                    <IconButton onClick={handleSelectDefaultCorridorClick} aria-label="add" color="primary">
+                    <FormLabel disabled={disabled} required>Default Corridor</FormLabel>
+                    <IconButton disabled={disabled} onClick={handleSelectDefaultCorridorClick} aria-label="add" color="primary">
                         <ListIcon/>
                     </IconButton>
                 </div>
                 <NameList
+                    disabled={disabled}
                     onClick={handleDefaultCorridorClick}
                     list={props.configuration.defaultCorridorCategory ? [props.configuration.defaultCorridorCategory] : []}
                 />
                 <div className={classes.listLabel}>
-                    <FormLabel>Corridors</FormLabel>
-                    <IconButton onClick={handleAddCorridorClick} aria-label="add" color="primary">
+                    <FormLabel disabled={disabled}>Corridors</FormLabel>
+                    <IconButton disabled={disabled} onClick={handleAddCorridorClick} aria-label="add" color="primary">
                         <AddBoxIcon />
                     </IconButton>
                 </div>
                 <ProbabilityNameList
+                    disabled={disabled}
                     showProbs
                     showDelete
                     list={props.configuration.corridorCategories}
@@ -232,7 +239,9 @@ const RegionLevelConfiguration = memo(
         prevProps.configuration.roomCategories === nextProps.configuration.roomCategories &&
         prevProps.configuration.corridorCategories === nextProps.configuration.corridorCategories &&
         prevProps.configuration.defaultRoomCategory === nextProps.configuration.defaultRoomCategory &&
-        prevProps.configuration.defaultCorridorCategory === nextProps.configuration.defaultCorridorCategory
+        prevProps.configuration.defaultCorridorCategory === nextProps.configuration.defaultCorridorCategory &&
+        prevProps.configuration.premade === nextProps.configuration.premade &&
+        prevProps.isSaving === nextProps.isSaving
 )
 
 

--- a/frontend/src/components/RegionLevelConfiguration.tsx
+++ b/frontend/src/components/RegionLevelConfiguration.tsx
@@ -106,12 +106,14 @@ const RegionLevelConfiguration = memo(
 
         const handleRoomDefaultSave = (rc: RoomCategory) => {
             props.onChange(nameOf<Configuration>("defaultRoomCategory"), rc);
+            setRoomCategoryToEdit(undefined);
             setRoomEditorOpen(false);
             setEditingDefault(false);
         }
 
         const handleCorridorDefaultSave = (cc: CorridorCategory) => {
             props.onChange(nameOf<Configuration>("defaultCorridorCategory"), cc);
+            setCorridorCategoryToEdit(undefined);
             setCorridorEditorOpen(false);
             setEditingDefault(false);
         }

--- a/frontend/src/components/RoomCategoryEditor.tsx
+++ b/frontend/src/components/RoomCategoryEditor.tsx
@@ -82,7 +82,7 @@ RoomCategoryEditor.defaultProps = {
 }
 
 export default function RoomCategoryEditor(props: Props) {
-  const editMode: boolean = props.roomCategory !== undefined
+  const editMode: boolean = props.roomCategory !== undefined && !props.roomCategory.premade
   const classes = useStyles();
   
   const [roomCategory, setRoomCategory] = useState(() => {
@@ -287,7 +287,7 @@ export default function RoomCategoryEditor(props: Props) {
           disableTypography
           id="form-dialog-title">
             <Grid container alignItems="center">
-              <Typography component={'span'} variant="h6">{editMode ? "Edit" : "Add"} Room Category</Typography>
+              <Typography component={'span'} variant="h6">{editMode ? "Edit" : viewMode ? "View" : "Add"} Room Category</Typography>
               <Tooltip
                   arrow
                   classes={{ tooltip: classes.customWidth }}

--- a/frontend/src/components/RoomCategoryEditor.tsx
+++ b/frontend/src/components/RoomCategoryEditor.tsx
@@ -119,18 +119,18 @@ export default function RoomCategoryEditor(props: Props) {
         })
       }
     }
-    setRoomCategory(Object.assign(Object.create(roomCategory), roomCategory, { [name]: value }) );
+    setRoomCategory(Object.assign(Object.create(Object.getPrototypeOf(roomCategory)), roomCategory, { [name]: value }) );
   }
 
   const handleDeleteClick = (name: keyof RoomCategory, index: number) => {
-    var updatedList = Object.create(roomCategory[name] as Probabilities<any>);
+    var updatedList = Object.create(Object.getPrototypeOf(roomCategory[name]) as Probabilities<any>);
     updatedList = Object.assign(updatedList, roomCategory[name]);
     updatedList.remove(index);
     handleChange(name, updatedList);
   }
 
   const handleSelect = (name: keyof RoomCategory, item: any) => {
-    var updatedList = Object.create(roomCategory[name] as Probabilities<any>);
+    var updatedList = Object.create(Object.getPrototypeOf(roomCategory[name]) as Probabilities<any>);
     updatedList = Object.assign(updatedList, roomCategory[name]);
     updatedList.add(item);
     handleChange(name, updatedList);
@@ -161,7 +161,7 @@ export default function RoomCategoryEditor(props: Props) {
   }
 
   const handleMonsterSave = (newMonster: Monster) => {
-    var updatedList = Object.create(roomCategory.monsters as Probabilities<Monster>);
+    var updatedList = Object.create(Object.getPrototypeOf(roomCategory.monsters) as Probabilities<Monster>);
     updatedList = Object.assign(updatedList, roomCategory.monsters);
     updatedList.updateObject(monsterToEdit!, newMonster);
     handleChange(nameOf<RoomCategory>("monsters"), updatedList);
@@ -187,7 +187,7 @@ export default function RoomCategoryEditor(props: Props) {
   }
 
   const handleItemSave = (newItem: Item) => {
-    var updatedList = Object.create(roomCategory.items as Probabilities<Item>);
+    var updatedList = Object.create(Object.getPrototypeOf(roomCategory.items) as Probabilities<Item>);
     updatedList = Object.assign(updatedList, roomCategory.items);
     updatedList.updateObject(itemToEdit!, newItem);
     handleChange(nameOf<RoomCategory>("items"), updatedList);
@@ -213,7 +213,7 @@ export default function RoomCategoryEditor(props: Props) {
   }
 
   const handleTrapSave = (newTrap: Trap) => {
-    var updatedList = Object.create(roomCategory.traps as Probabilities<Trap>);
+    var updatedList = Object.create(Object.getPrototypeOf(roomCategory.traps) as Probabilities<Trap>);
     updatedList = Object.assign(updatedList, roomCategory.traps);
     updatedList.updateObject(trapToEdit!, newTrap);
     handleChange(nameOf<RoomCategory>("traps"), updatedList);

--- a/frontend/src/components/TrapEditor.tsx
+++ b/frontend/src/components/TrapEditor.tsx
@@ -69,7 +69,7 @@ export default function TrapEditor(props: Props) {
         })
       }
     }
-    setTrap(Object.assign(Object.create(trap), trap, { [name]: value }) );
+    setTrap(Object.assign(Object.create(Object.getPrototypeOf(trap)), trap, { [name]: value }) );
   }
 
   const handleEditClick = () => {

--- a/frontend/src/components/TrapEditor.tsx
+++ b/frontend/src/components/TrapEditor.tsx
@@ -45,7 +45,7 @@ TrapEditor.defaultProps = {
 }
 
 export default function TrapEditor(props: Props) {
-  const editMode: boolean = props.trap !== undefined
+  const editMode: boolean = props.trap !== undefined && !props.trap.premade;
   const classes = useStyles();
 
   const [viewMode, setViewMode] = useState(props.viewOnly);
@@ -110,7 +110,7 @@ export default function TrapEditor(props: Props) {
           className={classes.root}
           disableTypography
           id="form-dialog-title">
-          <Typography component={'span'} variant="h6">{editMode ? "Edit" : "Add"} Trap</Typography>
+          <Typography component={'span'} variant="h6">{editMode ? "Edit" : viewMode ? "View" : "Add"} Trap</Typography>
           {viewMode && editMode &&
             <IconButton aria-label="edit" className={classes.editButton} onClick={handleEditClick}>
               <EditIcon />

--- a/frontend/src/components/common/EnumRadio.tsx
+++ b/frontend/src/components/common/EnumRadio.tsx
@@ -1,19 +1,24 @@
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import FormControl from '@material-ui/core/FormControl';
-import FormLabel from '@material-ui/core/FormLabel';
 
 type Props<EnumType extends number | string> = {
+    disabled?: boolean;
     label: string;
     value: EnumType;
     enum: {[s: string]: EnumType};
     onChange: (value: EnumType) => void;
 };
 
+EnumRadio.defaultProps = {
+    disabled: false
+}
+
 function EnumRadio<EnumType extends number | string>(props: Props<EnumType>) {
     return (
-        <FormControl>
+        <FormControl disabled={props.disabled}>
             <FormLabel component="legend">{props.label}</FormLabel>
             <RadioGroup row value={props.value} onChange={(e)=>props.onChange(e.target.value as EnumType)}>
                 {Object.values(props.enum).map(x =>

--- a/frontend/src/components/common/NameList.tsx
+++ b/frontend/src/components/common/NameList.tsx
@@ -42,8 +42,14 @@ function NameList<T extends hasName> (props: Props<T>) {
 
     const classes = useStyles();
 
+    const handleClick = (item: T) => {
+      if (props.onClick && !props.disabled) {
+        props.onClick(item)
+      }
+    }
+
     const listItems = props.list.map((item: T, i: number) =>
-      <ListItem button={(!props.disabled) as true} onClick={(e)=>props.onClick!(item)} key={i}>
+      <ListItem disabled={props.disabled} button={(!props.disabled) as true} onClick={(e)=>handleClick(item)} key={i}>
         <ListItemText
           primary={item.name}
         />

--- a/frontend/src/components/common/NameList.tsx
+++ b/frontend/src/components/common/NameList.tsx
@@ -1,12 +1,11 @@
-import { makeStyles } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
 import {
-  List,
+  IconButton, List,
   ListItem,
   ListItemSecondaryAction,
-  ListItemText,
-  IconButton
+  ListItemText
 } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import DeleteIcon from '@material-ui/icons/Delete';
 
 
 const useStyles = makeStyles((theme) => ({
@@ -28,13 +27,15 @@ interface hasName {
 
 type Props<T extends hasName> = {
   list: T[];
+  disabled?: boolean;
   showDelete?: boolean;
   onClick?: (item: T) => void;
   onDeleteClick?: (index: number) => void;
 }
 
 NameList.defaultProps = {
-  showDelete: false
+  showDelete: false,
+  disabled: false,
 }
 
 function NameList<T extends hasName> (props: Props<T>) {
@@ -42,13 +43,13 @@ function NameList<T extends hasName> (props: Props<T>) {
     const classes = useStyles();
 
     const listItems = props.list.map((item: T, i: number) =>
-      <ListItem button onClick={(e)=>props.onClick!(item)} key={i}>
+      <ListItem button={(!props.disabled) as true} onClick={(e)=>props.onClick!(item)} key={i}>
         <ListItemText
           primary={item.name}
         />
         {props.showDelete &&
           <ListItemSecondaryAction>
-            <IconButton onClick={()=>props.onDeleteClick!(i)} edge="end" aria-label="delete">
+            <IconButton disabled={props.disabled} onClick={()=>props.onDeleteClick!(i)} edge="end" aria-label="delete">
               <DeleteIcon />
             </IconButton>
           </ListItemSecondaryAction>

--- a/frontend/src/components/common/ProbabilityNameList.tsx
+++ b/frontend/src/components/common/ProbabilityNameList.tsx
@@ -1,12 +1,11 @@
-import { makeStyles } from '@material-ui/core/styles';
-import DeleteIcon from '@material-ui/icons/Delete';
+import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
-import IconButton from '@material-ui/core/IconButton';
+import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-
+import DeleteIcon from '@material-ui/icons/Delete';
 import { Probabilities } from '../../generator/Probabilities';
 
 
@@ -69,7 +68,7 @@ function ProbabilityNameList<T extends hasName> (props: Props<T>) {
     }
 
     const listItems = props.list ? props.list.objects.map((item: T, i: number) =>
-        <ListItem button={(!props.disabled) as true} onClick={(e)=>handleClick(item)} key={i}>
+        <ListItem disabled={props.disabled} button={(!props.disabled) as true} onClick={(e)=>handleClick(item)} key={i}>
           <ListItemText
             primary={item.name}
           />


### PR DESCRIPTION
#70 Frontend support for "premade" entities down the line. If its premade, then the user cannot edit them. Issue not complete, this is just in preparation for it
Closes #75 Fixed issue with "getAllCorridors", it was returning RoomCategory array 
Closes #71 Object.create calls were being used wrong, which resulted in nesting of the __prototype on the object